### PR TITLE
Finished driver

### DIFF
--- a/Drivers/inc/LTC2630.hpp
+++ b/Drivers/inc/LTC2630.hpp
@@ -13,30 +13,33 @@
 namespace SolarGators {
 namespace Drivers {
 
+
+typedef enum class OperatingMode : uint8_t{
+  Bit8 = 0,
+  Bit10 = 1,
+  Bit12 = 2
+} OperatingMode;
+
 class LTC2630 {
   SPI_HandleTypeDef* hspi_;
+  GPIO_TypeDef* cs_port_;
+  uint16_t cs_pin_;
   uint16_t current_val_;
   uint16_t pending_val_;
-  uint8_t mode_;
-  namespace Command
-  {
-    static constexpr uint8_t WriteData      = 0x00;
-    static constexpr uint8_t UpdateOutput   = 0x01;
-    static constexpr uint8_t WriteAndUpdate = 0x03;
-    static constexpr uint8_t PowerDown      = 0x04;
-    static constexpr uint8_t SetRefInternal = 0x06;
-    static constexpr uint8_t SetRefVcc      = 0x07;
-  }
+  OperatingMode mode_;
+
+  static constexpr uint8_t C_WriteData      = 0x00;
+  static constexpr uint8_t C_UpdateOutput   = 0x01;
+  static constexpr uint8_t C_WriteAndUpdate = 0x03;
+  static constexpr uint8_t C_PowerDown      = 0x04;
+  static constexpr uint8_t C_SetRefInternal = 0x06;
+  static constexpr uint8_t C_SetRefVcc      = 0x07;
+
   uint16_t AdjData(uint16_t data);
+  void Write(uint8_t command, uint16_t data);
 public:
 
-  typedef enum class uint8_t{
-    Bit8 = 0,
-    Bit10 = 1,
-    Bit12 = 2
-  } OperatingMode;
-
-  LTC2630(SPI_HandleTypeDef* hspi, OperatingMode mode);
+  LTC2630(SPI_HandleTypeDef* hspi, GPIO_TypeDef* cs_port, uint16_t cs_pin, OperatingMode mode);
   virtual ~LTC2630();
   void WriteData(uint16_t data);
   void UpdateOutput();

--- a/Drivers/inc/LTC2630.hpp
+++ b/Drivers/inc/LTC2630.hpp
@@ -40,6 +40,7 @@ class LTC2630 {
 public:
 
   LTC2630(SPI_HandleTypeDef* hspi, GPIO_TypeDef* cs_port, uint16_t cs_pin, OperatingMode mode);
+  void Init();
   virtual ~LTC2630();
   void WriteData(uint16_t data);
   void UpdateOutput();

--- a/Drivers/src/LTC2630.cpp
+++ b/Drivers/src/LTC2630.cpp
@@ -12,8 +12,11 @@ namespace Drivers {
 
 LTC2630::LTC2630(SPI_HandleTypeDef* hspi, GPIO_TypeDef* cs_port, uint16_t cs_pin, OperatingMode mode):
     hspi_(hspi), cs_port_(cs_port), cs_pin_(cs_pin), mode_(mode), current_val_(0)
+{ }
+
+void LTC2630::Init()
 {
-//  WriteAndUpdate(0x00);
+  WriteAndUpdate(0x00);
 }
 
 LTC2630::~LTC2630()

--- a/Drivers/src/LTC2630.cpp
+++ b/Drivers/src/LTC2630.cpp
@@ -10,9 +10,10 @@
 namespace SolarGators {
 namespace Drivers {
 
-LTC2630::LTC2630(SPI_HandleTypeDef* hspi, OperatingMode mode):hspi_(hspi),mode_(mode),current_val_(0)
+LTC2630::LTC2630(SPI_HandleTypeDef* hspi, GPIO_TypeDef* cs_port, uint16_t cs_pin, OperatingMode mode):
+    hspi_(hspi), cs_port_(cs_port), cs_pin_(cs_pin), mode_(mode), current_val_(0)
 {
-  WriteAndUpdate(0x00);
+//  WriteAndUpdate(0x00);
 }
 
 LTC2630::~LTC2630()
@@ -25,40 +26,42 @@ void LTC2630::WriteData(uint16_t data)
 {
   pending_val_ = data;
   data = AdjData(data);
-  uint8_t buff[3] = { Command::WriteData << 4, data & 0xff, data >> 8 };
-  HAL_SPI_Transmit(hspi_, &buff, 3, HAL_MAX_DELAY);
+  Write(C_WriteData, data);
 }
 void LTC2630::UpdateOutput()
 {
   uint16_t data = 0x0000;
-  uint8_t buff[3]={ Command::UpdateOutput << 4, data & 0xff, data >> 8 };
-  HAL_SPI_Transmit(hspi_, &buff, 3, HAL_MAX_DELAY);
+  Write(C_UpdateOutput, data);
   current_val_ = pending_val_;
 }
 void LTC2630::WriteAndUpdate(uint16_t data)
 {
   current_val_ = data;
   data = AdjData(data);
-  uint8_t buff[3]={ Command::WriteAndUpdate << 4, data & 0xff, data >> 8 };
-  HAL_SPI_Transmit(hspi_, &buff, 3, HAL_MAX_DELAY);
+  Write(C_WriteAndUpdate, data);
 }
 void LTC2630::PowerDown()
 {
   uint16_t data = 0x0000;
-  uint8_t buff[3]={ Command::PowerDown << 4, data & 0xff, data >> 8 };
-  HAL_SPI_Transmit(hspi_, &buff, 3, HAL_MAX_DELAY);
+  Write(C_PowerDown, data);
 }
 void LTC2630::SetRefInternal()
 {
   uint16_t data = 0x0000;
-  uint8_t buff[3]={ Command::SetRefInternal << 4, data & 0xff, data >> 8 };
-  HAL_SPI_Transmit(hspi_, &buff, 3, HAL_MAX_DELAY);
+  Write(C_SetRefInternal, data);
 }
 void LTC2630::SetRefVcc()
 {
   uint16_t data = 0x0000;
-  uint8_t buff[3]={ Command::SetRefVcc << 4, data & 0xff, data >> 8 };
-  HAL_SPI_Transmit(hspi_, &buff, 3, HAL_MAX_DELAY);
+  Write(C_SetRefVcc, data);
+}
+
+void LTC2630::Write(uint8_t command, uint16_t data)
+{
+  uint8_t buff[3]={ command << 4, data >> 8, data & 0xFF };
+  HAL_GPIO_WritePin(cs_port_, cs_pin_, GPIO_PIN_RESET);
+  HAL_SPI_Transmit(hspi_, buff, 3, HAL_MAX_DELAY);
+  HAL_GPIO_WritePin(cs_port_, cs_pin_, GPIO_PIN_SET);
 }
 
 uint16_t LTC2630::AdjData(uint16_t data)


### PR DESCRIPTION
Driver for the LTC2630 8 bit DAC.
Provides all functionality for the DAC in 8bit -> 12bit mode

Can be tested on the MC/Telem Board