### PR TITLE
Added support for ADCS747

### DIFF
--- a/Drivers/inc/ADCS747.hpp
+++ b/Drivers/inc/ADCS747.hpp
@@ -1,0 +1,32 @@
+/*
+ * ADCS747.hpp
+ *
+ *  Created on: Feb 24, 2022
+ *      Author: John Carr
+ */
+
+#ifndef SOLARGATORSBSP_STM_DRIVERS_INC_ADCS747_HPP_
+#define SOLARGATORSBSP_STM_DRIVERS_INC_ADCS747_HPP_
+
+#include "stm32f0xx_hal.h"
+
+namespace SolarGators {
+namespace Drivers {
+
+class ADCS747 {
+  const uint16_t DataWidth = 256;
+  SPI_HandleTypeDef* hspi_;
+  GPIO_TypeDef* cs_port_;
+  uint16_t cs_pin_;
+  void Read(uint8_t *);
+public:
+  ADCS747(SPI_HandleTypeDef* hspi, GPIO_TypeDef* port, uint16_t pin);
+  virtual ~ADCS747();
+  void Init();
+  uint8_t GetVoltage();
+};
+
+} /* namespace Drivers */
+} /* namespace SolarGators */
+
+#endif /* SOLARGATORSBSP_STM_DRIVERS_INC_ADCS747_HPP_ */

--- a/Drivers/src/ADCS747.cpp
+++ b/Drivers/src/ADCS747.cpp
@@ -1,0 +1,46 @@
+/*
+ * ADCS747.cpp
+ *
+ *  Created on: Feb 24, 2022
+ *      Author: John Carr
+ */
+
+#include <ADCS747.hpp>
+
+namespace SolarGators {
+namespace Drivers {
+
+ADCS747::ADCS747(SPI_HandleTypeDef* hspi, GPIO_TypeDef* cs_port, uint16_t cs_pin):
+    hspi_(hspi), cs_port_(cs_port), cs_pin_(cs_pin)
+{
+
+}
+
+ADCS747::~ADCS747() {
+  // TODO Auto-generated destructor stub
+}
+
+void ADCS747::Init()
+{
+  // Just need 16 clock cycles result of this is invalid
+  GetVoltage();
+}
+
+void ADCS747::Read(uint8_t* buff)
+{
+  HAL_GPIO_WritePin(cs_port_, cs_pin_, GPIO_PIN_RESET);
+  HAL_SPI_Receive(hspi_, buff, 2, HAL_MAX_DELAY);
+  HAL_GPIO_WritePin(cs_port_, cs_pin_, GPIO_PIN_SET);
+}
+
+uint8_t ADCS747::GetVoltage()
+{
+  uint8_t buff[2];
+  Read(buff);
+  uint16_t temp = static_cast<uint16_t>(buff[0]) << 8 | buff[1];
+  temp = temp >> 4;
+  return static_cast<uint8_t>(temp);
+}
+
+} /* namespace Drivers */
+} /* namespace SolarGators */


### PR DESCRIPTION
Driver for the ADCS747 ADC

This is used for reading throttle values from a 5v source.

IMPORTANT it was discovered that the VDIO for the IC is equal to VREF which we used as 5v meaning that this IC is unusable with the STM32 that is not 5v tolerant. 